### PR TITLE
[Feature] Allow splitting large projects into smaller ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ Join https://discord.gg/Y2gf5vZHpJ if you need any help with Scratch Everywhere!
 
 Like TurboWarp we have special custom blocks that only work on SE! You can find a project containing and explaining them here: https://scratchbox.grady.link/project/K26OtTN2WDJ9
 
+**Project Linking Blocks**
+- `open (____) .sb3`
+- `open (____) .sb3 with data (____)`
+- `received data` (variable)
+  
+These blocks make it possible to split a big game into smaller parts (e.g. a main game, a shop, or a cutscene project) and load them as needed. All paths are relative to the `scratch-everywhere` folder, so subfolders must be specified (e.g. `MyGame/main.sb3`).
+This helps avoid memory issues, keep projects modular, and makes it easier to manage large 
+games. 
+> [!NOTE]
+> In the future, this feature may be replaced by a dedicated extension once extension support is available.
+
 ## Limitations
 
 As this is in a very work in progress state, you will encounter many bugs, crashes, and things that will just not work. 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -63,7 +63,25 @@ int main(int argc, char **argv) {
     }
 
     while (Scratch::startScratchProject()) {
-        if (toExit || !activateMainMenu()) break;
+
+        if (Scratch::nextProject) {
+            Log::log(Unzip::filePath);
+            if (!Unzip::load()) {
+
+                if (Unzip::projectOpened == -3) { // main menu
+
+                    if (!activateMainMenu()) break;
+
+                } else {
+                    exitApp();
+                    break;
+                }
+            }
+        } else {
+            Unzip::filePath = "";
+            Scratch::nextProject = false;
+            if (toExit || !activateMainMenu()) break;
+        }
     }
     exitApp();
     return 0;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -80,6 +80,7 @@ int main(int argc, char **argv) {
         } else {
             Unzip::filePath = "";
             Scratch::nextProject = false;
+            Scratch::dataNextProject = Value();
             if (toExit || !activateMainMenu()) break;
         }
     }

--- a/source/scratch/blockExecutor.cpp
+++ b/source/scratch/blockExecutor.cpp
@@ -11,8 +11,8 @@
 #include "interpret.hpp"
 #include "math.hpp"
 #include "os.hpp"
-#include "unzip.hpp"
 #include "sprite.hpp"
+#include "unzip.hpp"
 #include <algorithm>
 #include <chrono>
 #include <cstddef>
@@ -328,7 +328,6 @@ BlockResult BlockExecutor::runCustomBlock(Sprite *sprite, Block &block, Block *c
     if (block.customBlockId == "\u200B\u200Blog\u200B\u200B %s") Log::log("[PROJECT] " + Scratch::getInputValue(block, "arg0", sprite).asString());
     if (block.customBlockId == "\u200B\u200Bwarn\u200B\u200B %s") Log::logWarning("[PROJECT] " + Scratch::getInputValue(block, "arg0", sprite).asString());
     if (block.customBlockId == "\u200B\u200Berror\u200B\u200B %s") Log::logError("[PROJECT] " + Scratch::getInputValue(block, "arg0", sprite).asString());
-    Log::log(block.customBlockId);
     if (block.customBlockId == "​open %s .sb3") {
         Log::log("Open next Project with Block");
         Scratch::nextProject = true;

--- a/source/scratch/blockExecutor.cpp
+++ b/source/scratch/blockExecutor.cpp
@@ -399,13 +399,9 @@ std::vector<Block *> BlockExecutor::runAllBlocksByOpcode(std::string opcodeToFin
                 // runBlock(data,currentSprite);
                 blocksRun.push_back(&data);
                 executor.runBlock(data, currentSprite);
-                // Wouldn't a 'goto' be useful here?
-                // Or do I just not understand this code well enough?
-                // goto returnBlocksRun;
             }
         }
     }
-    // returnBlocksRun:
     return blocksRun;
 }
 

--- a/source/scratch/blockExecutor.cpp
+++ b/source/scratch/blockExecutor.cpp
@@ -328,7 +328,7 @@ BlockResult BlockExecutor::runCustomBlock(Sprite *sprite, Block &block, Block *c
     if (block.customBlockId == "\u200B\u200Blog\u200B\u200B %s") Log::log("[PROJECT] " + Scratch::getInputValue(block, "arg0", sprite).asString());
     if (block.customBlockId == "\u200B\u200Bwarn\u200B\u200B %s") Log::logWarning("[PROJECT] " + Scratch::getInputValue(block, "arg0", sprite).asString());
     if (block.customBlockId == "\u200B\u200Berror\u200B\u200B %s") Log::logError("[PROJECT] " + Scratch::getInputValue(block, "arg0", sprite).asString());
-    if (block.customBlockId == "​open %s .sb3") {
+    if (block.customBlockId == "\u200B\u200Bopen\u200B\u200B %s .sb3") {
         Log::log("Open next Project with Block");
         Scratch::nextProject = true;
         Unzip::filePath = Scratch::getInputValue(block, "arg0", sprite).asString() + ".sb3";
@@ -336,7 +336,7 @@ BlockResult BlockExecutor::runCustomBlock(Sprite *sprite, Block &block, Block *c
         Scratch::shouldStop = true;
         return BlockResult::RETURN;
     }
-    if (block.customBlockId == "open %s .sb3 with data %s") {
+    if (block.customBlockId == "\u200B\u200Bopen\u200B\u200B %s .sb3 with data %s") {
         Log::log("Open next Project with Block and data");
         Scratch::nextProject = true;
         Unzip::filePath = Scratch::getInputValue(block, "arg0", sprite).asString() + ".sb3";

--- a/source/scratch/blockExecutor.cpp
+++ b/source/scratch/blockExecutor.cpp
@@ -380,9 +380,13 @@ std::vector<Block *> BlockExecutor::runAllBlocksByOpcode(std::string opcodeToFin
                 // runBlock(data,currentSprite);
                 blocksRun.push_back(&data);
                 executor.runBlock(data, currentSprite);
+                // Wouldn't a 'goto' be useful here?
+                // Or do I just not understand this code well enough?
+                // goto returnBlocksRun;
             }
         }
     }
+    // returnBlocksRun:
     return blocksRun;
 }
 

--- a/source/scratch/blockExecutor.cpp
+++ b/source/scratch/blockExecutor.cpp
@@ -11,6 +11,7 @@
 #include "interpret.hpp"
 #include "math.hpp"
 #include "os.hpp"
+#include "unzip.hpp"
 #include "sprite.hpp"
 #include <algorithm>
 #include <chrono>
@@ -286,7 +287,7 @@ void BlockExecutor::runRepeatsWithoutRefresh(Sprite *sprite, std::string blockCh
     }
 }
 
-void BlockExecutor::runCustomBlock(Sprite *sprite, Block &block, Block *callerBlock, bool *withoutScreenRefresh) {
+BlockResult BlockExecutor::runCustomBlock(Sprite *sprite, Block &block, Block *callerBlock, bool *withoutScreenRefresh) {
     for (auto &[id, data] : sprite->customBlocks) {
         if (id == block.customBlockId) {
             // Set up argument values
@@ -327,6 +328,24 @@ void BlockExecutor::runCustomBlock(Sprite *sprite, Block &block, Block *callerBl
     if (block.customBlockId == "\u200B\u200Blog\u200B\u200B %s") Log::log("[PROJECT] " + Scratch::getInputValue(block, "arg0", sprite).asString());
     if (block.customBlockId == "\u200B\u200Bwarn\u200B\u200B %s") Log::logWarning("[PROJECT] " + Scratch::getInputValue(block, "arg0", sprite).asString());
     if (block.customBlockId == "\u200B\u200Berror\u200B\u200B %s") Log::logError("[PROJECT] " + Scratch::getInputValue(block, "arg0", sprite).asString());
+    Log::log(block.customBlockId);
+    if (block.customBlockId == "​open %s .sb3") {
+        Log::log("Open next Project with Block");
+        Scratch::nextProject = true;
+        Unzip::filePath = Scratch::getInputValue(block, "arg0", sprite).asString() + ".sb3";
+        Scratch::dataNextProject = Value();
+        Scratch::shouldStop = true;
+        return BlockResult::RETURN;
+    }
+    if (block.customBlockId == "open %s .sb3 with data %s") {
+        Log::log("Open next Project with Block and data");
+        Scratch::nextProject = true;
+        Unzip::filePath = Scratch::getInputValue(block, "arg0", sprite).asString() + ".sb3";
+        Scratch::dataNextProject = Scratch::getInputValue(block, "arg1", sprite);
+        Scratch::shouldStop = true;
+        return BlockResult::RETURN;
+    }
+    return BlockResult::CONTINUE;
 }
 
 std::vector<std::pair<Block *, Sprite *>> BlockExecutor::runBroadcast(std::string broadcastToRun) {

--- a/source/scratch/blockExecutor.hpp
+++ b/source/scratch/blockExecutor.hpp
@@ -62,7 +62,7 @@ class BlockExecutor {
      * @param callerBlock Pointer to the block that activated the `Custom Block`.
      * @param withoutScreenRefresh Whether or not to run blocks inside the Definition without screen refresh.
      */
-    static void runCustomBlock(Sprite *sprite, Block &block, Block *callerBlock, bool *withoutScreenRefresh);
+    static BlockResult runCustomBlock(Sprite *sprite, Block &block, Block *callerBlock, bool *withoutScreenRefresh);
 
     /**
      * Runs and executes every block currently in the `broadcastQueue`.

--- a/source/scratch/blocks/procedure.cpp
+++ b/source/scratch/blocks/procedure.cpp
@@ -9,7 +9,7 @@ Value ProcedureBlocks::stringNumber(Block &block, Sprite *sprite) {
     if (name == "Scratch Everywhere! platform") {
         return Value(OS::getPlatform());
     }
-    if (name == "data last Project") {
+    if (name == "received data") {
         return Scratch::dataNextProject;
     }
     return BlockExecutor::getCustomBlockValue(name, sprite, block);

--- a/source/scratch/blocks/procedure.cpp
+++ b/source/scratch/blocks/procedure.cpp
@@ -5,11 +5,16 @@
 #include "value.hpp"
 
 Value ProcedureBlocks::stringNumber(Block &block, Sprite *sprite) {
-    if (Scratch::getFieldValue(block, "VALUE") == "Scratch Everywhere! platform") {
+    const std::string name = Scratch::getFieldValue(block, "VALUE");
+    if (name == "Scratch Everywhere! platform") {
         return Value(OS::getPlatform());
     }
-
-    return BlockExecutor::getCustomBlockValue(Scratch::getFieldValue(block, "VALUE"), sprite, block);
+    if (name == "data last Project") {
+        Log::log(Scratch::dataNextProject.asString());
+        Log::log("data");
+        return Scratch::dataNextProject;
+    }
+    return BlockExecutor::getCustomBlockValue(name, sprite, block);
 }
 
 Value ProcedureBlocks::booleanArgument(Block &block, Sprite *sprite) {
@@ -18,19 +23,13 @@ Value ProcedureBlocks::booleanArgument(Block &block, Sprite *sprite) {
     if (name == "is New 3DS?") {
         return Value(OS::isNew3DS());
     }
+    
 
-    Value value = BlockExecutor::getCustomBlockValue(Scratch::getFieldValue(block, "VALUE"), sprite, block);
+    Value value = BlockExecutor::getCustomBlockValue(name, sprite, block);
     return Value(value.asInt() == 1);
 }
 
 BlockResult ProcedureBlocks::call(Block &block, Sprite *sprite, bool *withoutScreenRefresh, bool fromRepeat) {
-    if (block.customBlockId == "​open %s .sb3") {
-        Log::log("Open next Project with Block");
-        Scratch::nextProject = true;
-        Unzip::filePath = Scratch::getInputValue(block, "arg0", sprite).asString() + ".sb3";
-        Scratch::shouldStop = true;
-        return BlockResult::RETURN;
-    }
 
     if (block.repeatTimes != -1 && !fromRepeat) {
         block.repeatTimes = -1;
@@ -41,7 +40,7 @@ BlockResult ProcedureBlocks::call(Block &block, Sprite *sprite, bool *withoutScr
         block.customBlockExecuted = false;
 
         // Run the custom block for the first time
-        BlockExecutor::runCustomBlock(sprite, block, &block, withoutScreenRefresh);
+        if (BlockExecutor::runCustomBlock(sprite, block, &block, withoutScreenRefresh) == BlockResult::RETURN) return BlockResult::RETURN;
         block.customBlockExecuted = true;
 
         BlockExecutor::addToRepeatQueue(sprite, &block);

--- a/source/scratch/blocks/procedure.cpp
+++ b/source/scratch/blocks/procedure.cpp
@@ -1,6 +1,7 @@
 #include "procedure.hpp"
 #include "blockExecutor.hpp"
 #include "sprite.hpp"
+#include "unzip.hpp"
 #include "value.hpp"
 
 Value ProcedureBlocks::stringNumber(Block &block, Sprite *sprite) {
@@ -23,6 +24,13 @@ Value ProcedureBlocks::booleanArgument(Block &block, Sprite *sprite) {
 }
 
 BlockResult ProcedureBlocks::call(Block &block, Sprite *sprite, bool *withoutScreenRefresh, bool fromRepeat) {
+    if (block.customBlockId == "​open %s .sb3") {
+        Log::log("Open next Project with Block");
+        Scratch::nextProject = true;
+        Unzip::filePath = Scratch::getInputValue(block, "arg0", sprite).asString() + ".sb3";
+        Scratch::shouldStop = true;
+        return BlockResult::RETURN;
+    }
 
     if (block.repeatTimes != -1 && !fromRepeat) {
         block.repeatTimes = -1;

--- a/source/scratch/blocks/procedure.cpp
+++ b/source/scratch/blocks/procedure.cpp
@@ -9,7 +9,7 @@ Value ProcedureBlocks::stringNumber(Block &block, Sprite *sprite) {
     if (name == "Scratch Everywhere! platform") {
         return Value(OS::getPlatform());
     }
-    if (name == "received data") {
+    if (name == "\u200B\u200Breceived data\u200B\u200B") {
         return Scratch::dataNextProject;
     }
     return BlockExecutor::getCustomBlockValue(name, sprite, block);

--- a/source/scratch/blocks/procedure.cpp
+++ b/source/scratch/blocks/procedure.cpp
@@ -10,8 +10,6 @@ Value ProcedureBlocks::stringNumber(Block &block, Sprite *sprite) {
         return Value(OS::getPlatform());
     }
     if (name == "data last Project") {
-        Log::log(Scratch::dataNextProject.asString());
-        Log::log("data");
         return Scratch::dataNextProject;
     }
     return BlockExecutor::getCustomBlockValue(name, sprite, block);
@@ -23,7 +21,6 @@ Value ProcedureBlocks::booleanArgument(Block &block, Sprite *sprite) {
     if (name == "is New 3DS?") {
         return Value(OS::isNew3DS());
     }
-    
 
     Value value = BlockExecutor::getCustomBlockValue(name, sprite, block);
     return Value(value.asInt() == 1);

--- a/source/scratch/interpret.cpp
+++ b/source/scratch/interpret.cpp
@@ -56,6 +56,7 @@ bool Scratch::miscellaneousLimits = true;
 bool Scratch::shouldStop = false;
 
 bool Scratch::nextProject = false;
+Value Scratch::dataNextProject;
 
 #ifdef ENABLE_CLOUDVARS
 bool cloudProject = false;

--- a/source/scratch/interpret.cpp
+++ b/source/scratch/interpret.cpp
@@ -55,6 +55,8 @@ bool Scratch::fencing = true;
 bool Scratch::miscellaneousLimits = true;
 bool Scratch::shouldStop = false;
 
+bool Scratch::nextProject = false;
+
 #ifdef ENABLE_CLOUDVARS
 bool cloudProject = false;
 #endif
@@ -120,6 +122,7 @@ bool Scratch::startScratchProject() {
 #ifdef ENABLE_CLOUDVARS
     if (cloudProject && !projectJSON.empty()) initMist();
 #endif
+    Scratch::nextProject = false;
 
     BlockExecutor::runAllBlocksByOpcode("event_whenflagclicked");
     BlockExecutor::timer.start();
@@ -190,7 +193,7 @@ void Scratch::cleanupScratchProject() {
     Scratch::fencing = true;
     Scratch::miscellaneousLimits = true;
     Render::renderMode = Render::TOP_SCREEN_ONLY;
-    Unzip::filePath = "";
+    // Unzip::filePath = "";
     Log::log("Cleaned up Scratch project.");
 }
 

--- a/source/scratch/interpret.hpp
+++ b/source/scratch/interpret.hpp
@@ -51,6 +51,7 @@ class Scratch {
     static bool shouldStop;
 
     static bool nextProject;
+    static Value dataNextProject;
 };
 
 /**

--- a/source/scratch/interpret.hpp
+++ b/source/scratch/interpret.hpp
@@ -49,6 +49,8 @@ class Scratch {
     static bool fencing;
     static bool miscellaneousLimits;
     static bool shouldStop;
+
+    static bool nextProject;
 };
 
 /**

--- a/source/scratch/unzip.cpp
+++ b/source/scratch/unzip.cpp
@@ -68,7 +68,7 @@ int Unzip::openFile(std::ifstream *file) {
                     file->open(OS::getScratchFolderLocation() + filePath + "/project.json", std::ios::binary | std::ios::ate);
                     if (!(*file)) {
                         Log::logError("Couldnt open Unpacked Scratch File");
-                        Log::logWarning(filePath + "<");
+                        Log::logWarning(filePath);
                         return 0;
                     }
                     filePath = OS::getScratchFolderLocation() + filePath + "/";


### PR DESCRIPTION
Some users have run into issues when trying to launch Scratch projects in Scratch Everywhere, mostly because their projects were simply too big.
To make this a bit easier, I thought about adding a way to switch .sb3 files directly inside a running project.

Of course, this doesn’t magically make oversized Scratch projects work on SE!,  but it could give developers the option to split a large project into multiple smaller ones and then switch between them internally.

Right now, this is just a prototype. It’s basically one of the “My Blocks” that I tweaked (similar to how the logging blocks were modified). It works like this: "open %s .sb3" with "arg0" as the parameter.

What’s still missing is some way to share data between those smaller projects, so this is definitely not finished yet.

Not sure if this is really useful as a proper feature, but I wanted to put the idea out there and hear your thoughts.