### PR TITLE
fix(runtime): Replace std::rand() with new RNG to avoid modulo bias

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -87,9 +87,6 @@ int main(int argc, char **argv) {
         return 1;
     }
 
-    srand(time(NULL));
-
-    if (argc > 1) {
 #ifdef __EMSCRIPTEN__
         while (!OS::fileExists("/romfs/project.sb3")) {
             if (!Render::appShouldRun()) {

--- a/source/scratch/blocks/control.cpp
+++ b/source/scratch/blocks/control.cpp
@@ -1,9 +1,10 @@
 #include "control.hpp"
-#include "../audio.hpp"
+#include "audio.hpp"
 #include "blockExecutor.hpp"
 #include "interpret.hpp"
 #include "math.hpp"
 #include "os.hpp"
+#include "random.hpp"
 #include "sprite.hpp"
 #include "value.hpp"
 #include <iostream>
@@ -103,7 +104,7 @@ BlockResult ControlBlocks::createCloneOf(Block &block, Sprite *sprite, bool *wit
         spriteToClone->isClone = true;
         spriteToClone->isStage = false;
         spriteToClone->toDelete = false;
-        spriteToClone->id = Math::generateRandomString(15);
+        spriteToClone->id = Random::get().randomString(15);
         // Log::log("Cloned " + sprite->name);
         //  add clone to sprite list
         sprites.push_back(spriteToClone);

--- a/source/scratch/blocks/data.cpp
+++ b/source/scratch/blocks/data.cpp
@@ -2,6 +2,7 @@
 #include "blockExecutor.hpp"
 #include "interpret.hpp"
 #include "math.hpp"
+#include "random.hpp"
 #include "render.hpp"
 #include "sprite.hpp"
 #include "value.hpp"
@@ -119,8 +120,8 @@ BlockResult DataBlocks::deleteFromList(Block &block, Sprite *sprite, bool *witho
     }
     if (val.asString() == "all") items.clear();
 
-    if ((val.asString() == "random" || val.asString() == "any") && !items.empty()) {
-        int idx = rand() % items.size();
+    if (val.asString() == "random" && !items.empty()) {
+        int idx = Random::get().randomRange(items.size());
         items.erase(items.begin() + idx);
     }
 
@@ -175,7 +176,7 @@ BlockResult DataBlocks::insertAtList(Block &block, Sprite *sprite, bool *without
 
     if (index.asString() == "random" || index.asString() == "any") {
         auto &items = targetSprite->lists[listId].items;
-        int idx = rand() % (items.size() + 1);
+        int idx = Random::get().randomRange(items.size() + 1);
         items.insert(items.begin() + idx, val);
     }
 
@@ -209,7 +210,7 @@ BlockResult DataBlocks::replaceItemOfList(Block &block, Sprite *sprite, bool *wi
     if (index.asString() == "last" && !items.empty()) items.back() = val;
 
     if ((index.asString() == "random" || index.asString() == "any") && !items.empty()) {
-        int idx = rand() % items.size();
+        int idx = Random::get().randomRange(items.size());
         items[idx] = val;
         return BlockResult::CONTINUE;
     }
@@ -236,7 +237,7 @@ Value DataBlocks::itemOfList(Block &block, Sprite *sprite) {
     if (indexStr.asString() == "last") return items.back();
 
     if ((indexStr.asString() == "random" || indexStr.asString() == "any") && !items.empty()) {
-        int idx = rand() % items.size();
+        int idx = Random::get().randomRange(items.size());
         return items[idx];
     }
 

--- a/source/scratch/blocks/looks.cpp
+++ b/source/scratch/blocks/looks.cpp
@@ -3,6 +3,7 @@
 #include "image.hpp"
 #include "interpret.hpp"
 #include "math.hpp"
+#include "random.hpp"
 #include "sprite.hpp"
 #include "unzip.hpp"
 #include "value.hpp"
@@ -79,7 +80,7 @@ BlockResult LooksBlocks::switchBackdropTo(Block &block, Sprite *sprite, bool *wi
         return BlockResult::CONTINUE;
     } else if (inputValue.asString() == "random backdrop") {
         if (stageSprite->costumes.size() == 1) return BlockResult::CONTINUE;
-        int randomIndex = std::rand() % (stageSprite->costumes.size() - 1);
+        int randomIndex = Random::get().randomRange(stageSprite->costumes.size() - 1);
         if (randomIndex >= stageSprite->currentCostume) randomIndex++;
         Scratch::switchCostume(stageSprite, randomIndex);
         return BlockResult::CONTINUE;

--- a/source/scratch/blocks/motion.cpp
+++ b/source/scratch/blocks/motion.cpp
@@ -1,9 +1,10 @@
 #include "motion.hpp"
-#include "../render.hpp"
+#include "render.hpp"
 #include "blockExecutor.hpp"
 #include "input.hpp"
 #include "interpret.hpp"
 #include "math.hpp"
+#include "random.hpp"
 #include "render.hpp"
 #include "sprite.hpp"
 #include "value.hpp"
@@ -11,7 +12,6 @@
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
-#include <math.h>
 #include <ostream>
 #include <string>
 
@@ -39,8 +39,8 @@ BlockResult MotionBlocks::goTo(Block &block, Sprite *sprite, bool *withoutScreen
     const double oldY = sprite->yPosition;
 
     if (objectName.asString() == "_random_") {
-        sprite->xPosition = rand() % Scratch::projectWidth - Scratch::projectWidth / 2;
-        sprite->yPosition = rand() % Scratch::projectHeight - Scratch::projectHeight / 2;
+        sprite->xPosition = Random::get().randomRange(Scratch::projectWidth) - (Scratch::projectWidth / 2);
+        sprite->yPosition = Random::get().randomRange(Scratch::projectHeight) - (Scratch::projectHeight / 2);
         goto end;
     }
 
@@ -253,8 +253,8 @@ BlockResult MotionBlocks::glideTo(Block &block, Sprite *sprite, bool *withoutScr
         std::string positionYStr;
 
         if (inputValue.asString() == "_random_") {
-            positionXStr = std::to_string(rand() % Scratch::projectWidth - Scratch::projectWidth / 2);
-            positionYStr = std::to_string(rand() % Scratch::projectHeight - Scratch::projectHeight / 2);
+            positionXStr = std::to_string(Random::get().randomRange(Scratch::projectWidth) - (Scratch::projectWidth / 2));
+            positionYStr = std::to_string(Random::get().randomRange(Scratch::projectHeight) - (Scratch::projectHeight / 2));
         } else if (inputValue.asString() == "_mouse_") {
             positionXStr = std::to_string(Input::mousePointer.x);
             positionYStr = std::to_string(Input::mousePointer.y);
@@ -309,7 +309,7 @@ BlockResult MotionBlocks::pointToward(Block &block, Sprite *sprite, bool *withou
     double targetY = 0;
 
     if (objectName.asString() == "_random_") {
-        sprite->rotation = rand() % 360;
+        sprite->rotation = Random::get().randomRange(360);
         return BlockResult::CONTINUE;
     }
 

--- a/source/scratch/blocks/operator.cpp
+++ b/source/scratch/blocks/operator.cpp
@@ -1,5 +1,6 @@
 #include "operator.hpp"
-#include "../math.hpp"
+#include "math.hpp"
+#include "random.hpp"
 #include "interpret.hpp"
 #include "sprite.hpp"
 #include "value.hpp"
@@ -7,7 +8,6 @@
 #include <cctype>
 #include <cmath>
 #include <cstdlib>
-#include <math.h>
 
 Value OperatorBlocks::add(Block &block, Sprite *sprite) {
     Value value1 = Scratch::getInputValue(block, "NUM1", sprite);
@@ -42,14 +42,13 @@ Value OperatorBlocks::random(Block &block, Sprite *sprite) {
 
     if (a == b) return Value(a);
 
-    double from = std::min(a, b);
-    double to = std::max(a, b);
+    auto [from, to] = std::minmax(a, b);
 
     if (value1.isScratchInt() && value2.isScratchInt()) {
-        return Value(from + (rand() % static_cast<int>(to + 1 - from)));
-    } else {
-        return Value(from + static_cast<double>(rand()) / (static_cast<double>(RAND_MAX) / (to - from)));
+        return Value(Random::get().randomInt(static_cast<uint32_t>(from), static_cast<uint32_t>(to)));
     }
+
+    return Value(Random::get().randomDouble(from, to));
 }
 
 Value OperatorBlocks::join(Block &block, Sprite *sprite) {
@@ -100,46 +99,46 @@ Value OperatorBlocks::mathOp(Block &block, Sprite *sprite) {
         double value = inputValue.asDouble();
 
         if (operation == "abs") {
-            return Value(abs(value));
+            return Value(std::abs(value));
         }
         if (operation == "floor") {
-            return Value(floor(value));
+            return Value(static_cast<int>(std::floor(value)));
         }
         if (operation == "ceiling") {
-            return Value(ceil(value));
+            return Value(static_cast<int>(std::ceil(value)));
         }
         if (operation == "sqrt") {
-            return Value(sqrt(value));
+            return Value(std::sqrt(value));
         }
         if (operation == "sin") {
-            return Value(sin(value * M_PI / 180.0));
+            return Value(std::sin(value * M_PI / 180.0));
         }
         if (operation == "cos") {
-            return Value(cos(value * M_PI / 180.0));
+            return Value(std::cos(value * M_PI / 180.0));
         }
         if (operation == "tan") {
-            return Value(tan(value * M_PI / 180.0));
+            return Value(std::tan(value * M_PI / 180.0));
         }
         if (operation == "asin") {
-            return Value(asin(value) * 180.0 / M_PI);
+            return Value(std::asin(value) * 180.0 / M_PI);
         }
         if (operation == "acos") {
-            return Value(acos(value) * 180.0 / M_PI);
+            return Value(std::acos(value) * 180.0 / M_PI);
         }
         if (operation == "atan") {
-            return Value(atan(value) * 180.0 / M_PI);
+            return Value(std::atan(value) * 180.0 / M_PI);
         }
         if (operation == "ln") {
-            return Value(log(value));
+            return Value(std::log(value));
         }
         if (operation == "log") {
-            return Value(log10(value));
+            return Value(std::log10(value));
         }
         if (operation == "e ^") {
-            return Value(exp(value));
+            return Value(std::exp(value));
         }
         if (operation == "10 ^") {
-            return Value(pow(10, value));
+            return Value(std::pow(10, value));
         }
     }
     return Value(0);

--- a/source/scratch/interpret.cpp
+++ b/source/scratch/interpret.cpp
@@ -6,13 +6,13 @@
 #include "math.hpp"
 #include "nlohmann/json.hpp"
 #include "os.hpp"
+#include "random.hpp"
 #include "render.hpp"
 #include "sprite.hpp"
 #include "unzip.hpp"
 #include <cmath>
 #include <cstddef>
 #include <cstring>
-#include <math.h>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -24,7 +24,6 @@
 
 #ifdef ENABLE_CLOUDVARS
 #include <mist/mist.hpp>
-#include <random>
 #include <sstream>
 
 const uint64_t FNV_PRIME_64 = 1099511628211ULL;
@@ -298,7 +297,7 @@ std::pair<float, float> Scratch::screenToScratchCoords(float screenX, float scre
 void initializeSpritePool(int poolSize) {
     for (int i = 0; i < poolSize; i++) {
         Sprite newSprite;
-        newSprite.id = Math::generateRandomString(15);
+        newSprite.id = Random::get().randomString(15);
         newSprite.isClone = true;
         newSprite.toDelete = true;
         newSprite.isDeleted = true;
@@ -623,7 +622,7 @@ void loadSprites(const nlohmann::json &json) {
         if (target.contains("name")) {
             newSprite->name = target["name"].get<std::string>();
         }
-        newSprite->id = Math::generateRandomString(15);
+        newSprite->id = Random::get().randomString(15);
         if (target.contains("isStage")) {
             newSprite->isStage = target["isStage"].get<bool>();
         }
@@ -931,12 +930,12 @@ void loadSprites(const nlohmann::json &json) {
         if (monitor.contains("width") && !(monitor["width"].is_null() || monitor.at("width").get<int>() == 0))
             newMonitor.width = monitor.at("width").get<int>();
         else
-        	newMonitor.width = 110;
+            newMonitor.width = 110;
 
         if (monitor.contains("height") && !(monitor["height"].is_null() || monitor.at("height").get<int>() == 0))
             newMonitor.height = monitor.at("height").get<int>();
         else
-        	newMonitor.height = 200;
+            newMonitor.height = 200;
 
         if (monitor.contains("visible") && !monitor["visible"].is_null())
             newMonitor.visible = monitor.at("visible").get<bool>();

--- a/source/scratch/math.cpp
+++ b/source/scratch/math.cpp
@@ -1,41 +1,29 @@
 #include "math.hpp"
 #include <algorithm>
-#include <ctime>
+#include <cmath>
 #include <limits>
-#include <math.h>
-#include <random>
 #include <stdexcept>
-#include <string>
 #ifdef __3DS__
 #include <citro2d.h>
-#endif
-#ifdef __NDS__
+#elif defined(__NDS__)
 #include <nds.h>
 #endif
 
-int Math::color(int r, int g, int b, int a) {
-    r = std::clamp(r, 0, 255);
-    g = std::clamp(g, 0, 255);
-    b = std::clamp(b, 0, 255);
-    a = std::clamp(a, 0, 255);
-
+uint32_t Math::color(uint8_t r, uint8_t g, uint8_t b, uint8_t a) {
 #ifdef __NDS__
     int r5 = r >> 3;
     int g5 = g >> 3;
     int b5 = b >> 3;
     return RGB15(r5, g5, b5);
-#elif defined(RENDERER_SDL1) || defined(RENDERER_SDL2) || defined(RENDERER_SDL3)
-    return (r << 24) |
-           (g << 16) |
-           (b << 8) |
-           a;
+#elif defined(RENDERER_SDL2) || defined(RENDERER_SDL3)
+    return (r << 24) | (g << 16) | (b << 8) | a;
 #elif defined(__3DS__)
     return C2D_Color32(r, g, b, a);
 #endif
     return 0;
 }
 
-double Math::parseNumber(std::string str) {
+double Math::parseNumber(const std::string str) {
     // Scratch has whitespace trimming
     while (std::isspace(str[0]) && !str.empty()) {
         str.erase(0, 1);
@@ -116,33 +104,22 @@ bool Math::isNumber(const std::string &str) {
 }
 
 double Math::degreesToRadians(double degrees) {
-    return degrees * (M_PI / 180.0);
+    return degrees * (PI / 180.0);
 }
 
 double Math::radiansToDegrees(double radians) {
-    return radians * (180.0 / M_PI);
+    return radians * (180.0 / PI);
 }
 
-std::string Math::generateRandomString(int length) {
-    std::string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890-=[];',./_+{}|:<>?~`";
-    std::string result;
-
-    static std::mt19937 generator(static_cast<unsigned int>(std::time(nullptr)));
-    std::uniform_int_distribution<> distribution(0, chars.size() - 1);
-
-    for (int i = 0; i < length; i++) {
-        result += chars[distribution(generator)];
+std::string Math::removeDoubleQuotes(std::string_view str) {
+    if (value.size() >= 2 && value.front() == '"' && value.back() == '"') {
+        value.remove_prefix(1);
+        value.remove_suffix(1);
     }
-
-    return result;
+    return std::string(value);
 }
 
-std::string Math::removeQuotations(std::string value) {
-    value.erase(std::remove_if(value.begin(), value.end(), [](char c) { return c == '"'; }), value.end());
-    return value;
-}
-
-const uint32_t Math::next_pow2(uint32_t n) {
+uint32_t Math::next_pow2(uint32_t n) {
     n--;
     n |= n >> 1;
     n |= n >> 2;

--- a/source/scratch/math.hpp
+++ b/source/scratch/math.hpp
@@ -1,24 +1,20 @@
 #pragma once
 #include <cstdint>
 #include <string>
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
+#include <string_view>
 
 namespace Math {
+constexpr double PI = 3.14159265358979323846;
 
 bool isNumber(const std::string &str);
-double parseNumber(std::string str);
+double parseNumber(const std::string str);
 
-int color(int r, int g, int b, int a);
+uint32_t color(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 
 double degreesToRadians(double degrees);
-
 double radiansToDegrees(double radians);
 
-std::string generateRandomString(int length);
+std::string removeDoubleQuotes(std::string_view str);
 
-std::string removeQuotations(std::string value);
-
-const uint32_t next_pow2(uint32_t n);
+uint32_t next_pow2(uint32_t n);
 }; // namespace Math

--- a/source/scratch/menus/menuObjects.hpp
+++ b/source/scratch/menus/menuObjects.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "image.hpp"
 #include "os.hpp"
+#include "random.hpp"
 #include "render.hpp"
 #include "text.hpp"
 
@@ -33,9 +34,9 @@ class JollySnow {
 
         for (size_t i = 0; i < 30; i++) {
             SnowFall ball = {
-                .x = (float)(rand() % Render::getWidth()),
-                .y = (float)(rand() % Render::getHeight()),
-                .fallSpeed = ((float)rand() / RAND_MAX) * 1.1f + 0.2f};
+                .x = Random::get().randomFloat(static_cast<float>(Render::getWidth())),
+                .y = Random::get().randomFloat(static_cast<float>(Render::getHeight())),
+                .fallSpeed = Random::get().randomFloat(0.25f, 1.25f};
             snow.push_back(std::move(ball));
         }
     }
@@ -46,7 +47,7 @@ class JollySnow {
             ball.y += ball.fallSpeed;
             if (ball.y > Render::getHeight() + 20 - yOffset) {
                 ball.y = -20 - yOffset;
-                ball.x = (float)(rand() % Render::getWidth());
+                ball.x = Random::get().randomFloat(static_cast<float>(Render::getWidth()));
             }
         }
 
@@ -54,8 +55,8 @@ class JollySnow {
             oldWindowWidth = Render::getWidth();
             oldWindowHeight = Render::getHeight();
             for (auto &ball : snow) {
-                ball.x = (float)(rand() % Render::getWidth());
-                ball.y = (float)(rand() % Render::getHeight());
+                ball.x = Random::get().randomFloat(static_cast<float>(Render::getWidth()));
+                ball.y = Random::get().randomFloat(static_cast<float>(Render::getHeight()));
             }
         }
     }

--- a/source/scratch/random.cpp
+++ b/source/scratch/random.cpp
@@ -1,0 +1,196 @@
+#include "random.hpp"
+#include <array>
+#include <cassert>
+#include <chrono>
+#include <random>
+#include <string_view>
+
+static const std::string_view printableChars =
+    " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNO"
+    "PQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
+
+template <int k, typename T>
+static inline T rotl(const T x) {
+    return (x << k) | (x >> (std::numeric_limits<T>::digits - k));
+}
+
+static inline uint64_t splitmix64(uint64_t &x) {
+    uint64_t result = (x += 0x9e3779b97f4a7c15);
+    result = (result ^ (result >> 30)) * 0xbf58476d1ce4e5b9;
+    result = (result ^ (result >> 27)) * 0x94d049bb133111eb;
+    return result ^ (result >> 31);
+}
+
+static inline uint32_t generateSeed() {
+    uint32_t seed = static_cast<uint32_t>(std::chrono::high_resolution_clock::now()
+                                              .time_since_epoch()
+                                              .count());
+
+    // Add some randomness from std::random_device
+    std::random_device rd;
+    seed ^= rd();
+
+    return seed;
+}
+
+Random::Random() : Random(generateSeed()) {}
+
+Random::Random(uint32_t seed) {
+    uint64_t s = seed;
+    state[0] = static_cast<uint32_t>(splitmix64(s));
+    state[1] = static_cast<uint32_t>(splitmix64(s));
+    state[2] = static_cast<uint32_t>(splitmix64(s));
+    state[3] = static_cast<uint32_t>(splitmix64(s));
+}
+
+Random &Random::get() {
+    static Random instance;
+    return instance;
+}
+
+uint32_t Random::randomInt() {
+    const uint32_t result = rotl<7>(state[1] * 5) * 9;
+    const uint32_t t = state[1] << 9;
+
+    state[2] ^= state[0];
+    state[3] ^= state[1];
+    state[1] ^= state[2];
+    state[0] ^= state[3];
+
+    state[2] ^= t;
+    state[3] = rotl<11>(state[3]);
+
+    return result;
+}
+
+uint32_t Random::randomRange(uint32_t range) {
+    assert(range != 0);
+    uint32_t num = randomInt();
+    uint64_t mid = static_cast<uint64_t>(num) * static_cast<uint64_t>(range);
+    uint32_t low = static_cast<uint32_t>(mid);
+    if (low < range) {
+        uint32_t threshold = -range % range;
+        while (low < threshold) {
+            num = randomInt();
+            mid = static_cast<uint64_t>(num) * static_cast<uint64_t>(range);
+            low = static_cast<uint32_t>(mid);
+        }
+    }
+    return mid >> 32;
+}
+
+uint32_t Random::randomInt(uint32_t start, uint32_t end) {
+    assert(end > start);
+    return start + randomRange(end - start + 1);
+}
+
+float Random::randomFloat() {
+    return (randomInt() >> 8) * 0x1.0p-24f;
+}
+
+float Random::randomFloat(float start, float end) {
+    assert(end > start);
+    float num = randomFloat();
+    return start + num * (end - start);
+}
+
+double Random::randomDouble() {
+    return ((static_cast<uint64_t>(randomInt()) |
+             (static_cast<uint64_t>(randomInt()) << 32)) >>
+            11) *
+           0x1.0p-53;
+}
+
+double Random::randomDouble(double start, double end) {
+    assert(end > start);
+    double num = randomDouble();
+    return start + num * (end - start);
+}
+
+std::string Random::randomString(size_t length) {
+    std::string result;
+    result.resize(length);
+
+    for (size_t i = 0; i < length; i++) {
+        result[i] = printableChars[randomRange(printableChars.size())];
+    }
+
+    return result;
+}
+
+// 64-bit version
+Random64::Random64() : Random64(static_cast<uint64_t>(generateSeed()) |
+                                (static_cast<uint64_t>(generateSeed()) << 32)) {}
+
+Random64::Random64(uint64_t seed) {
+    uint64_t s = seed;
+    state[0] = splitmix64(s);
+    state[1] = splitmix64(s);
+    state[2] = splitmix64(s);
+    state[3] = splitmix64(s);
+}
+
+Random64 &Random64::get() {
+    static Random64 instance;
+    return instance;
+}
+
+uint64_t Random64::randomInt() {
+    const uint64_t result = rotl<7>(state[1] * 5) * 9;
+    const uint64_t t = state[1] << 17;
+
+    state[2] ^= state[0];
+    state[3] ^= state[1];
+    state[1] ^= state[2];
+    state[0] ^= state[3];
+
+    state[2] ^= t;
+    state[3] = rotl<45>(state[3]);
+
+    return result;
+}
+
+uint64_t Random64::randomRange(uint64_t range) {
+    uint64_t threshold = -range % range;
+    uint64_t num;
+    do {
+        num = randomInt();
+    } while (num < threshold);
+    return num % range;
+}
+
+uint64_t Random64::randomInt(uint64_t start, uint64_t end) {
+    assert(end > start);
+    return start + randomRange(end - start + 1);
+}
+
+float Random64::randomFloat() {
+    return (static_cast<uint32_t>(randomInt()) >> 8) * 0x1.0p-24f;
+}
+
+float Random64::randomFloat(float start, float end) {
+    assert(end > start);
+    float num = randomFloat();
+    return start + num * (end - start);
+}
+
+double Random64::randomDouble() {
+    return (randomInt() >> 11) * 0x1.0p-53;
+}
+
+double Random64::randomDouble(double start, double end) {
+    assert(end > start);
+    double num = randomDouble();
+    return start + num * (end - start);
+}
+
+std::string Random64::randomString(size_t length) {
+    std::string result;
+    result.resize(length);
+
+    for (size_t i = 0; i < length; i++) {
+        result[i] = printableChars[randomRange(printableChars.size())];
+    }
+
+    return result;
+}

--- a/source/scratch/random.hpp
+++ b/source/scratch/random.hpp
@@ -1,0 +1,51 @@
+#pragma once
+#include <cstdint>
+#include <string>
+
+class Random {
+  private:
+    uint32_t state[4];
+
+  public:
+    Random();
+    Random(uint32_t seed);
+
+    // Returns a global RNG instance
+    static Random &get();
+
+    uint32_t randomInt();
+    uint32_t randomRange(uint32_t range);
+    uint32_t randomInt(uint32_t start, uint32_t end);
+
+    float randomFloat();
+    float randomFloat(float start, float end);
+
+    double randomDouble();
+    double randomDouble(double start, double end);
+
+    std::string randomString(size_t length);
+};
+
+class Random64 {
+  private:
+    uint64_t state[4];
+
+  public:
+    Random64();
+    Random64(uint64_t seed);
+
+    // Returns a global RNG instance
+    static Random64 &get();
+
+    uint64_t randomInt();
+    uint64_t randomRange(uint64_t range);
+    uint64_t randomInt(uint64_t start, uint64_t end);
+
+    float randomFloat();
+    float randomFloat(float start, float end);
+
+    double randomDouble();
+    double randomDouble(double start, double end);
+
+    std::string randomString(size_t length);
+};

--- a/source/scratch/unzip.hpp
+++ b/source/scratch/unzip.hpp
@@ -3,10 +3,10 @@
 #include "interpret.hpp"
 #include "miniz.h"
 #include "os.hpp"
+#include "random.hpp"
 #include <cstring>
 #include <errno.h>
 #include <fstream>
-#include <random>
 #include <sys/stat.h>
 #include <sys/types.h>
 
@@ -32,6 +32,7 @@ class Unzip {
     static std::vector<char> zipBuffer;
 
     static void openScratchProject(void *arg) {
+        (void)arg;
         loadingState = "Opening Scratch project";
         Unzip::UnpackedInSD = false;
         std::istream *file = nullptr;
@@ -161,11 +162,9 @@ class Unzip {
             return "Everywhere!"; // fallback if file is empty
         }
 
-        // Initialize random number generator with current time
-        static std::mt19937 rng(static_cast<unsigned int>(std::time(nullptr)));
-        std::uniform_int_distribution<size_t> dist(0, splashLines.size() - 1);
+        size_t randomIndex = Random::get().randomRange(splashLines.size());
 
-        std::string splash = splashLines[dist(rng)];
+        std::string splash = splashLines[randomIndex];
 
         // Replace {PlatformName} with OS::getPlatform()
         const std::string platformName = "{PlatformName}";


### PR DESCRIPTION
(Does not depend on PR [#465](https://github.com/ScratchEverywhere/ScratchEverywhere/pull/465))

Replaced `std::rand()` with the xoshiro128** PRNG (in the newly implemented `Random` class) for better quality and performance.

---

### Changes:
- Fixed modulo bias caused by using `rand() % range` to get a random range
- Moved `Math::generateRandomString()` to `Random::randomString()`
- Renamed `Math::removeQuotations` to `Math::removeDoubleQuotes` and updated to use `std::string_view` as input

### To-do:
- [ ] Add compile-time selection between 32-bit and 64-bit RNGs