### PR TITLE
fix(runtime): Avoid overflows when using `Value::asString()` with doubles

### DIFF
--- a/source/scratch/value.cpp
+++ b/source/scratch/value.cpp
@@ -64,10 +64,16 @@ std::string Value::asString() const {
         return std::to_string(std::get<int>(value));
     } else if (isDouble()) {
         double doubleValue = std::get<double>(value);
-        int bufferSize = std::snprintf(nullptr, 0, "%g", doubleValue);
-        std::vector<char> buf(bufferSize + 1);
-        std::snprintf(buf.data(), buf.size(), "%g", doubleValue);
-        return std::string(buf.data(), buf.data() + bufferSize);
+        // NaN values MUST return "NaN", and Inf values MUST return either
+        // "-Infinity" or "Infinity" string constants
+        if (std::isnan(doubleValue)) return "NaN"; 
+        else if (std::isinf(doubleValue)) return std::signbit(doubleValue) ? "-Infinity" : "Infinity";
+        else {
+            int bufferSize = std::snprintf(nullptr, 0, "%g", doubleValue);
+            std::vector<char> buf(bufferSize + 1);
+            std::snprintf(buf.data(), buf.size(), "%g", doubleValue);
+            return std::string(buf.data(), buf.data() + bufferSize);
+        }
     } else if (isString()) {
         return std::get<std::string>(value);
     } else if (isBoolean()) {

--- a/source/scratch/value.cpp
+++ b/source/scratch/value.cpp
@@ -64,11 +64,10 @@ std::string Value::asString() const {
         return std::to_string(std::get<int>(value));
     } else if (isDouble()) {
         double doubleValue = std::get<double>(value);
-        // handle whole numbers too, because scratch i guess
-        if (std::isnan(doubleValue)) return "NaN";
-        if (std::isinf(doubleValue)) return std::signbit(doubleValue) ? "-Infinity" : "Infinity";
-        if (std::floor(doubleValue) == doubleValue) return std::to_string(static_cast<int>(doubleValue));
-        return std::to_string(doubleValue);
+        int bufferSize = std::snprintf(nullptr, 0, "%g", doubleValue);
+        std::vector<char> buf(bufferSize + 1);
+        std::snprintf(buf.data(), buf.size(), "%g", doubleValue);
+        return std::string(buf.data(), buf.data() + bufferSize);
     } else if (isString()) {
         return std::get<std::string>(value);
     } else if (isBoolean()) {

--- a/source/scratch/value.cpp
+++ b/source/scratch/value.cpp
@@ -65,7 +65,7 @@ std::string Value::asString() const {
     } else if (isDouble()) {
         double doubleValue = std::get<double>(value);
         // NaN values MUST return "NaN", and Inf values MUST return either
-        // "-Infinity" or "Infinity" string constants
+        // "-Infinity" or "Infinity" string literals
         if (std::isnan(doubleValue)) return "NaN"; 
         else if (std::isinf(doubleValue)) return std::signbit(doubleValue) ? "-Infinity" : "Infinity";
         else {


### PR DESCRIPTION
Uses `std::snprintf()` to automatically format doubles. A more modern option might be `std::format`, but that won't work on older platforms that don't have a modern implementation of `std` (specifically C++20).