### PR TITLE
[Audio] Fix IMA ADPCM loading and channel collision

### DIFF
--- a/source/sdl2/audio/audio.cpp
+++ b/source/sdl2/audio/audio.cpp
@@ -19,6 +19,196 @@ std::unordered_map<std::string, std::unique_ptr<SDL_Audio>> SDL_Sounds;
 std::string currentStreamedSound = "";
 static bool isInit = false;
 
+// IMA ADPCM step table
+static const int ima_step_table[89] = {
+    7, 8, 9, 10, 11, 12, 13, 14, 16, 17,
+    19, 21, 23, 25, 28, 31, 34, 37, 41, 45,
+    50, 55, 60, 66, 73, 80, 88, 97, 107, 118,
+    130, 143, 157, 173, 190, 209, 230, 253, 279, 307,
+    337, 371, 408, 449, 494, 544, 598, 658, 724, 796,
+    876, 963, 1060, 1166, 1282, 1411, 1552, 1707, 1878, 2066,
+    2272, 2499, 2749, 3024, 3327, 3660, 4026, 4428, 4871, 5358,
+    5894, 6484, 7132, 7845, 8630, 9493, 10442, 11487, 12635, 13899,
+    15289, 16818, 18500, 20350, 22385, 24623, 27086, 29794, 32767};
+
+// IMA ADPCM index table
+static const int ima_index_table[16] = {
+    -1, -1, -1, -1, 2, 4, 6, 8,
+    -1, -1, -1, -1, 2, 4, 6, 8};
+
+// Decode a single IMA ADPCM nibble
+static int16_t decodeADPCMNibble(uint8_t nibble, int16_t &predictor, int &stepIndex) {
+    int step = ima_step_table[stepIndex];
+    int diff = step >> 3;
+
+    if (nibble & 1) diff += step >> 2;
+    if (nibble & 2) diff += step >> 1;
+    if (nibble & 4) diff += step;
+    if (nibble & 8) diff = -diff;
+
+    predictor += diff;
+    if (predictor > 32767) predictor = 32767;
+    if (predictor < -32768) predictor = -32768;
+
+    stepIndex += ima_index_table[nibble];
+    if (stepIndex < 0) stepIndex = 0;
+    if (stepIndex > 88) stepIndex = 88;
+
+    return predictor;
+}
+
+// Convert IMA ADPCM WAV to PCM WAV in memory
+// Returns nullptr on failure, caller must free() the returned buffer
+static void *decodeADPCMtoPCM(const void *adpcmData, size_t adpcmSize, size_t *outPcmSize) {
+    const uint8_t *data = (const uint8_t *)adpcmData;
+
+    // Verify RIFF/WAVE header
+    if (adpcmSize < 44 || memcmp(data, "RIFF", 4) != 0 || memcmp(data + 8, "WAVE", 4) != 0) {
+        return nullptr;
+    }
+
+    // Parse fmt chunk
+    size_t pos = 12;
+    uint16_t channels = 0, bitsPerSample = 0, blockAlign = 0;
+    uint32_t sampleRate = 0;
+    size_t dataOffset = 0, dataSize = 0;
+
+    while (pos + 8 <= adpcmSize) {
+        uint32_t chunkSize = data[pos + 4] | (data[pos + 5] << 8) | (data[pos + 6] << 16) | (data[pos + 7] << 24);
+
+        if (memcmp(data + pos, "fmt ", 4) == 0) {
+            if (pos + 8 + chunkSize > adpcmSize || chunkSize < 20) return nullptr;
+            uint16_t format = data[pos + 8] | (data[pos + 9] << 8);
+            if (format != 0x11) return nullptr; // Not IMA ADPCM
+
+            channels = data[pos + 10] | (data[pos + 11] << 8);
+            sampleRate = data[pos + 12] | (data[pos + 13] << 8) | (data[pos + 14] << 16) | (data[pos + 15] << 24);
+            blockAlign = data[pos + 20] | (data[pos + 21] << 8);
+            bitsPerSample = data[pos + 22] | (data[pos + 23] << 8);
+        } else if (memcmp(data + pos, "data", 4) == 0) {
+            dataOffset = pos + 8;
+            dataSize = chunkSize;
+            break;
+        }
+        pos += 8 + chunkSize;
+        if (chunkSize & 1) pos++; // Padding
+    }
+
+    if (dataOffset == 0 || dataSize == 0 || channels == 0 || blockAlign == 0) {
+        return nullptr;
+    }
+
+    // Calculate output size
+    // IMA ADPCM: 4 bits per sample, but block has 4-byte header per channel
+    size_t samplesPerBlock = (blockAlign - 4 * channels) * 2 / channels + 1;
+    size_t numBlocks = (dataSize + blockAlign - 1) / blockAlign;
+    size_t totalSamples = numBlocks * samplesPerBlock * channels;
+    size_t pcmDataSize = totalSamples * 2; // 16-bit output
+
+    // Allocate output buffer (WAV header + PCM data)
+    size_t pcmFileSize = 44 + pcmDataSize;
+    uint8_t *pcmBuffer = (uint8_t *)malloc(pcmFileSize);
+    if (!pcmBuffer) return nullptr;
+
+    // Write WAV header
+    memcpy(pcmBuffer, "RIFF", 4);
+    uint32_t riffSize = pcmFileSize - 8;
+    pcmBuffer[4] = riffSize & 0xFF;
+    pcmBuffer[5] = (riffSize >> 8) & 0xFF;
+    pcmBuffer[6] = (riffSize >> 16) & 0xFF;
+    pcmBuffer[7] = (riffSize >> 24) & 0xFF;
+    memcpy(pcmBuffer + 8, "WAVE", 4);
+    memcpy(pcmBuffer + 12, "fmt ", 4);
+    pcmBuffer[16] = 16;
+    pcmBuffer[17] = 0;
+    pcmBuffer[18] = 0;
+    pcmBuffer[19] = 0; // fmt chunk size
+    pcmBuffer[20] = 1;
+    pcmBuffer[21] = 0; // PCM format
+    pcmBuffer[22] = channels & 0xFF;
+    pcmBuffer[23] = (channels >> 8) & 0xFF;
+    pcmBuffer[24] = sampleRate & 0xFF;
+    pcmBuffer[25] = (sampleRate >> 8) & 0xFF;
+    pcmBuffer[26] = (sampleRate >> 16) & 0xFF;
+    pcmBuffer[27] = (sampleRate >> 24) & 0xFF;
+    uint32_t byteRate = sampleRate * channels * 2;
+    pcmBuffer[28] = byteRate & 0xFF;
+    pcmBuffer[29] = (byteRate >> 8) & 0xFF;
+    pcmBuffer[30] = (byteRate >> 16) & 0xFF;
+    pcmBuffer[31] = (byteRate >> 24) & 0xFF;
+    uint16_t pcmBlockAlign = channels * 2;
+    pcmBuffer[32] = pcmBlockAlign & 0xFF;
+    pcmBuffer[33] = (pcmBlockAlign >> 8) & 0xFF;
+    pcmBuffer[34] = 16;
+    pcmBuffer[35] = 0; // 16 bits per sample
+    memcpy(pcmBuffer + 36, "data", 4);
+    pcmBuffer[40] = pcmDataSize & 0xFF;
+    pcmBuffer[41] = (pcmDataSize >> 8) & 0xFF;
+    pcmBuffer[42] = (pcmDataSize >> 16) & 0xFF;
+    pcmBuffer[43] = (pcmDataSize >> 24) & 0xFF;
+
+    // Decode ADPCM blocks
+    int16_t *pcmOut = (int16_t *)(pcmBuffer + 44);
+    size_t outPos = 0;
+    const uint8_t *blockPtr = data + dataOffset;
+    size_t remaining = dataSize;
+
+    while (remaining >= (size_t)blockAlign) {
+        // Each block starts with predictor and step index for each channel
+        int16_t predictor[2] = {0, 0};
+        int stepIndex[2] = {0, 0};
+
+        for (int ch = 0; ch < channels; ch++) {
+            predictor[ch] = (int16_t)(blockPtr[ch * 4] | (blockPtr[ch * 4 + 1] << 8));
+            stepIndex[ch] = blockPtr[ch * 4 + 2];
+            if (stepIndex[ch] > 88) stepIndex[ch] = 88;
+
+            // First sample is the predictor itself
+            if (outPos < totalSamples) {
+                pcmOut[outPos++] = predictor[ch];
+            }
+        }
+
+        // Decode the rest of the block
+        const uint8_t *adpcmBytes = blockPtr + 4 * channels;
+        size_t bytesInBlock = blockAlign - 4 * channels;
+
+        if (channels == 1) {
+            // Mono: sequential nibbles
+            for (size_t i = 0; i < bytesInBlock && outPos < totalSamples; i++) {
+                uint8_t byte = adpcmBytes[i];
+                pcmOut[outPos++] = decodeADPCMNibble(byte & 0x0F, predictor[0], stepIndex[0]);
+                if (outPos < totalSamples) {
+                    pcmOut[outPos++] = decodeADPCMNibble((byte >> 4) & 0x0F, predictor[0], stepIndex[0]);
+                }
+            }
+        } else {
+            // Stereo: interleaved 4-byte chunks per channel
+            for (size_t i = 0; i < bytesInBlock && outPos < totalSamples; i += 8) {
+                // 4 bytes for left channel, then 4 bytes for right
+                for (int chunk = 0; chunk < 2 && (i + chunk * 4) < bytesInBlock; chunk++) {
+                    int ch = chunk;
+                    for (int b = 0; b < 4 && outPos < totalSamples; b++) {
+                        uint8_t byte = adpcmBytes[i + chunk * 4 + b];
+                        int16_t samp1 = decodeADPCMNibble(byte & 0x0F, predictor[ch], stepIndex[ch]);
+                        int16_t samp2 = decodeADPCMNibble((byte >> 4) & 0x0F, predictor[ch], stepIndex[ch]);
+                        // For stereo, we need to interleave properly
+                        // This simplified version may not be perfect for stereo
+                        pcmOut[outPos++] = samp1;
+                        if (outPos < totalSamples) pcmOut[outPos++] = samp2;
+                    }
+                }
+            }
+        }
+
+        blockPtr += blockAlign;
+        remaining -= blockAlign;
+    }
+
+    *outPcmSize = pcmFileSize;
+    return pcmBuffer;
+}
+
 #ifdef ENABLE_AUDIO
 SDL_Audio::SDL_Audio() : audioChunk(nullptr) {}
 #endif
@@ -34,7 +224,11 @@ SDL_Audio::~SDL_Audio() {
         music = nullptr;
     }
     if (file_data && file_data != nullptr && isStreaming) {
-        mz_free(file_data);
+        if (useStdFree) {
+            free(file_data);
+        } else {
+            mz_free(file_data);
+        }
     }
 #endif
 }
@@ -127,29 +321,64 @@ bool SoundPlayer::loadSoundFromSB3(Sprite *sprite, mz_zip_archive *zip, const st
 
             Mix_Music *music = nullptr;
             Mix_Chunk *chunk = nullptr;
+            bool useStreaming = streamed; // Local copy we can modify
 
-            SDL_RWops *rw = SDL_RWFromMem(file_data, (int)file_size);
-            if (!rw) {
-                Log::logWarning("Failed to create RWops for: " + zipFileName);
+            // Check if this is IMA ADPCM format (format tag 0x11 at offset 20)
+            unsigned char *bytes = (unsigned char *)file_data;
+            bool isADPCM = (file_size > 22 && bytes[20] == 0x11 && bytes[21] == 0x00);
+
+            // If ADPCM, decode to PCM in memory first
+            void *audioData = file_data;
+            size_t audioSize = file_size;
+            bool needsFreeAudioData = false;
+
+            if (isADPCM) {
+                size_t pcmSize = 0;
+                void *pcmData = decodeADPCMtoPCM(file_data, file_size, &pcmSize);
                 mz_free(file_data);
-                return false;
+
+                if (!pcmData) {
+                    Log::logWarning("Failed to decode ADPCM: " + zipFileName);
+                    return false;
+                }
+                audioData = pcmData;
+                audioSize = pcmSize;
+                needsFreeAudioData = true;
             }
 
-            if (!streamed) {
+            if (!useStreaming) {
+                SDL_RWops *rw = SDL_RWFromMem(audioData, (int)audioSize);
+                if (!rw) {
+                    Log::logWarning("Failed to create RWops for: " + zipFileName);
+                    if (needsFreeAudioData) free(audioData);
+                    else mz_free(audioData);
+                    return false;
+                }
                 chunk = Mix_LoadWAV_RW(rw, 1);
-                mz_free(file_data);
+                if (needsFreeAudioData) free(audioData);
+                else mz_free(audioData);
 
                 if (!chunk) {
                     Log::logWarning("Failed to load audio from memory: " + zipFileName + " - SDL_mixer Error: " + Mix_GetError());
                     return false;
                 }
             } else {
+                SDL_RWops *rw = SDL_RWFromMem(audioData, (int)audioSize);
+                if (!rw) {
+                    Log::logWarning("Failed to create RWops for: " + zipFileName);
+                    if (needsFreeAudioData) free(audioData);
+                    else mz_free(audioData);
+                    return false;
+                }
                 music = Mix_LoadMUS_RW(rw, 1);
                 if (!music) {
                     Log::logWarning("Failed to load audio from memory: " + zipFileName + " - SDL_mixer Error: " + Mix_GetError());
-                    mz_free(file_data);
+                    if (needsFreeAudioData) free(audioData);
+                    else mz_free(audioData);
                     return false;
                 }
+                // Note: for streaming, SDL_mixer keeps reference to RWops,
+                // audioData must stay alive - we store it for cleanup in destructor
             }
 
             // Create SDL_Audio object
@@ -160,19 +389,21 @@ bool SoundPlayer::loadSoundFromSB3(Sprite *sprite, mz_zip_archive *zip, const st
                 SDL_Sounds[soundId] = std::move(audio);
             }
 
-            if (!streamed) {
+            if (!useStreaming) {
                 SDL_Sounds[soundId]->audioChunk = chunk;
             } else {
                 SDL_Sounds[soundId]->music = music;
                 SDL_Sounds[soundId]->isStreaming = true;
+                // Store audioData for streaming - needed by SDL_mixer, freed in destructor
+                SDL_Sounds[soundId]->file_data = audioData;
+                SDL_Sounds[soundId]->file_size = audioSize;
+                SDL_Sounds[soundId]->useStdFree = needsFreeAudioData; // true if decoded ADPCM (malloc)
             }
             SDL_Sounds[soundId]->audioId = soundId;
 
             Log::log("Successfully loaded audio!");
             SDL_Sounds[soundId]->isLoaded = true;
-            SDL_Sounds[soundId]->file_data = file_data;
             SDL_Sounds[soundId]->channelId = SDL_Sounds.size();
-            SDL_Sounds[soundId]->file_size = file_size;
             playSound(soundId);
             setSoundVolume(soundId, sprite->volume);
             return true;
@@ -385,10 +616,13 @@ void SoundPlayer::stopSound(const std::string &soundId) {
         if (!soundFind->second->isStreaming) {
             int channel = soundFind->second->channelId;
             if (channel >= 0 && channel < Mix_AllocateChannels(-1)) {
-                Mix_HaltChannel(channel);
+                // Only halt if this sound's chunk is actually playing on this channel
+                // Prevents stopping other sounds that took over the channel
+                Mix_Chunk *playing = Mix_GetChunk(channel);
+                if (playing == soundFind->second->audioChunk) {
+                    Mix_HaltChannel(channel);
+                }
                 soundFind->second->isPlaying = false;
-            } else {
-                Log::logWarning("Invalid channel for sound: " + soundId);
             }
         } else {
             stopStreamedSound();

--- a/source/sdl2/audio/audio.hpp
+++ b/source/sdl2/audio/audio.hpp
@@ -18,6 +18,7 @@ class SDL_Audio {
     bool isLoaded = false;
     bool isPlaying = false;
     bool isStreaming = false;
+    bool useStdFree = false; // True if file_data was allocated with malloc (vs mz_alloc)
     bool needsToBePlayed = true;
     bool smoothTransition = false;
     double musicPosition = 0.0;


### PR DESCRIPTION
- Implement in-memory ADPCM to PCM decoder
- Fix channel collision: verify chunk before halting

SDL_mixer fails to decode ADPCM from RWops. Afaic this is the least bad fix given constraints: no temp files (disk I/O), no new deps, no file bloat from pre-converting audio (also disk I/O), and an upstream SDL fix(?) is out of scope.

Repro: https://turbowarp.org/258765038 (music wouldn't play)