### PR TITLE
Fix building when SDL is not in the default include path

### DIFF
--- a/source/audio/sdl1/audio.cpp
+++ b/source/audio/sdl1/audio.cpp
@@ -1,7 +1,7 @@
 #include "audio.hpp"
 #include "audiostack.hpp"
 #include "os.hpp"
-#include <SDL/SDL.h>
+#include <SDL.h>
 #include <log.hpp>
 #include <vector>
 

--- a/source/audio/sdl2/audio.cpp
+++ b/source/audio/sdl2/audio.cpp
@@ -1,7 +1,7 @@
 #include "audio.hpp"
 #include "audiostack.hpp"
 #include "os.hpp"
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <log.hpp>
 #include <vector>
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -20,10 +20,6 @@
 #include <switch.h>
 #endif
 
-#ifdef RENDERER_SDL2
-#include <SDL2/SDL.h>
-#endif
-
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
 #include <emscripten_browser_file.h>
@@ -91,7 +87,7 @@ void mainLoop() {
     }
 }
 
-#ifdef WINDOWING_SDL1
+#if defined(WINDOWING_SDL1) || defined(WINDOWING_SDL2)
 #include <SDL.h>
 
 extern "C" int main(int argc, char **argv) {

--- a/source/platforms/ps4/thread.cpp
+++ b/source/platforms/ps4/thread.cpp
@@ -1,4 +1,4 @@
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <thread.hpp>
 
 // just using SDL2 threads/mutexes for now

--- a/source/platforms/psp/thread.cpp
+++ b/source/platforms/psp/thread.cpp
@@ -1,4 +1,4 @@
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <thread.hpp>
 
 // just using SDL2 threads/mutexes for now

--- a/source/platforms/switch/thread.cpp
+++ b/source/platforms/switch/thread.cpp
@@ -1,4 +1,4 @@
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <thread.hpp>
 
 // just using SDL2 threads/mutexes for now

--- a/source/platforms/vita/thread.cpp
+++ b/source/platforms/vita/thread.cpp
@@ -1,4 +1,4 @@
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <thread.hpp>
 
 // just using SDL2 threads/mutexes for now

--- a/source/renderers/sdl1/image_sdl1.cpp
+++ b/source/renderers/sdl1/image_sdl1.cpp
@@ -1,8 +1,8 @@
 #include "image_sdl1.hpp"
 #include "nonstd/expected.hpp"
 #include "render.hpp"
-#include <SDL/SDL_gfxBlitFunc.h>
-#include <SDL/SDL_rotozoom.h>
+#include <SDL_gfxBlitFunc.h>
+#include <SDL_rotozoom.h>
 #include <algorithm>
 #include <cctype>
 #include <cstddef>

--- a/source/renderers/sdl1/image_sdl1.hpp
+++ b/source/renderers/sdl1/image_sdl1.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <SDL/SDL.h>
+#include <SDL.h>
 #include <image.hpp>
 #include <nonstd/expected.hpp>
 #include <string>

--- a/source/renderers/sdl1/render.cpp
+++ b/source/renderers/sdl1/render.cpp
@@ -1,9 +1,9 @@
 #include "render.hpp"
 #include "speech_manager_sdl1.hpp"
-#include <SDL/SDL.h>
-#include <SDL/SDL_gfxBlitFunc.h>
-#include <SDL/SDL_gfxPrimitives.h>
-#include <SDL/SDL_rotozoom.h>
+#include <SDL.h>
+#include <SDL_gfxBlitFunc.h>
+#include <SDL_gfxPrimitives.h>
+#include <SDL_rotozoom.h>
 #include <algorithm>
 #include <audio.hpp>
 #include <cmath>

--- a/source/renderers/sdl1/render.hpp
+++ b/source/renderers/sdl1/render.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#include <SDL/SDL.h>
-#include <SDL/SDL_ttf.h>
+#include <SDL.h>
+#include <SDL_ttf.h>
 
 #if SDL_BYTEORDER == SDL_BIG_ENDIAN
 #define RMASK 0xff000000

--- a/source/renderers/sdl1/speech_manager_sdl1.cpp
+++ b/source/renderers/sdl1/speech_manager_sdl1.cpp
@@ -1,8 +1,8 @@
 #include "speech_manager_sdl1.hpp"
 #include "render.hpp"
-#include <SDL/SDL.h>
-#include <SDL/SDL_gfxBlitFunc.h>
-#include <SDL/SDL_rotozoom.h>
+#include <SDL.h>
+#include <SDL_gfxBlitFunc.h>
+#include <SDL_rotozoom.h>
 #include <image.hpp>
 #include <image_sdl1.hpp>
 #include <render.hpp>

--- a/source/renderers/sdl1/speech_manager_sdl1.hpp
+++ b/source/renderers/sdl1/speech_manager_sdl1.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "speech_text_sdl1.hpp"
-#include <SDL/SDL.h>
+#include <SDL.h>
 #include <memory>
 #include <speech_manager.hpp>
 

--- a/source/renderers/sdl1/speech_text_sdl1.cpp
+++ b/source/renderers/sdl1/speech_text_sdl1.cpp
@@ -1,7 +1,7 @@
 #include "speech_text_sdl1.hpp"
 #include "text.hpp"
-#include <SDL/SDL.h>
-#include <SDL/SDL_ttf.h>
+#include <SDL.h>
+#include <SDL_ttf.h>
 #include <log.hpp>
 #include <os.hpp>
 

--- a/source/renderers/sdl1/text_sdl1.cpp
+++ b/source/renderers/sdl1/text_sdl1.cpp
@@ -1,8 +1,8 @@
 #include "text_sdl1.hpp"
 #include "render.hpp"
-#include <SDL/SDL_gfxBlitFunc.h>
-#include <SDL/SDL_rotozoom.h>
-#include <SDL/SDL_video.h>
+#include <SDL_gfxBlitFunc.h>
+#include <SDL_rotozoom.h>
+#include <SDL_video.h>
 #include <iostream>
 #include <log.hpp>
 #include <os.hpp>

--- a/source/renderers/sdl1/text_sdl1.hpp
+++ b/source/renderers/sdl1/text_sdl1.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#include <SDL/SDL.h>
-#include <SDL/SDL_ttf.h>
+#include <SDL.h>
+#include <SDL_ttf.h>
 #include <text.hpp>
 #include <unordered_map>
 

--- a/source/renderers/sdl2/image_sdl2.hpp
+++ b/source/renderers/sdl2/image_sdl2.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include "nonstd/expected.hpp"
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <image.hpp>
 #include <string>
 

--- a/source/renderers/sdl2/render.cpp
+++ b/source/renderers/sdl2/render.cpp
@@ -2,7 +2,7 @@
 #include "speech_manager.hpp"
 #include "speech_manager_sdl2.hpp"
 #include "sprite.hpp"
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <algorithm>
 #include <audio.hpp>
 #include <cmath>

--- a/source/renderers/sdl2/render.hpp
+++ b/source/renderers/sdl2/render.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <SDL_ttf.h>
 
 extern SDL_Renderer *renderer;

--- a/source/renderers/sdl2/speech_manager_sdl2.hpp
+++ b/source/renderers/sdl2/speech_manager_sdl2.hpp
@@ -2,7 +2,7 @@
 
 #include "speech_manager.hpp"
 #include "speech_text_sdl2.hpp"
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <memory>
 
 class Image;

--- a/source/renderers/sdl2/speech_text_sdl2.cpp
+++ b/source/renderers/sdl2/speech_text_sdl2.cpp
@@ -1,6 +1,6 @@
 #include "speech_text_sdl2.hpp"
 #include "text.hpp"
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <SDL_ttf.h>
 #include <log.hpp>
 #include <os.hpp>

--- a/source/renderers/sdl2/text_sdl2.hpp
+++ b/source/renderers/sdl2/text_sdl2.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <SDL_ttf.h>
 #include <text.hpp>
 #include <unordered_map>

--- a/source/runtime/blocks/ScratchEverywhere.cpp
+++ b/source/runtime/blocks/ScratchEverywhere.cpp
@@ -2,11 +2,11 @@
 #include "os.hpp"
 
 #if defined(RENDERER_SDL1) && defined(PLATFORM_HAS_CONTROLLER)
-#include <SDL/SDL.h>
+#include <SDL.h>
 
 extern SDL_Joystick *controller;
 #elif defined(RENDERER_SDL2) && defined(PLATFORM_HAS_CONTROLLER)
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 extern SDL_GameController *controller;
 #elif defined(RENDERER_SDL3) && defined(PLATFORM_HAS_CONTROLLER)

--- a/source/windowing/sdl1/window.hpp
+++ b/source/windowing/sdl1/window.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <SDL/SDL.h>
+#include <SDL.h>
 #include <window.hpp>
 
 #ifdef RENDERER_OPENGL

--- a/source/windowing/sdl2/window.hpp
+++ b/source/windowing/sdl2/window.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <window.hpp>
 
 class WindowSDL2 : public Window {


### PR DESCRIPTION
This is needed when SDL is installed via Homebrew, where SDL is installed in a non-default location, and only the `SDL2` subdirectory is included in the output from `sdl2-config --cflags`. This is only necessary for SDL1 and SDL2 - SDL3 includes the directory containing the `SDL3` subdirectory instead.